### PR TITLE
fix: refactor isSpec function to use magic-regexp lib for cleaner regex

### DIFF
--- a/src/utils/is-spec.ts
+++ b/src/utils/is-spec.ts
@@ -1,3 +1,4 @@
+import { anyOf, char, createRegExp, oneOrMore } from 'magic-regexp';
 import { getFilenameComponents } from './get-file';
 
 /**
@@ -5,7 +6,10 @@ import { getFilenameComponents } from './get-file';
  */
 export function isSpec(path: string, specPatterns: string[]) {
   const { name } = getFilenameComponents(path);
-  return specPatterns.some((pattern) => {
-    return new RegExp(`${pattern}$`).test(name);
-  });
+  const regex = createRegExp(
+    oneOrMore(char),
+    anyOf(...specPatterns).at.lineEnd()
+  );
+
+  return regex.test(name);
 }

--- a/tests/utils/is-spec.test.ts
+++ b/tests/utils/is-spec.test.ts
@@ -9,6 +9,8 @@ test.each([
   ['a/b/c/get.ts', false],
   ['a/b/c/test.ts', false],
   ['a/b/c/get.test.example.ts', false],
+  ['a/b/c/is-spec.ts', false],
+  ['a/b/c/.spec.ts', false],
 ] satisfies Case[])('isSpec(%s) -> %j', (target, expected) => {
   const result = isSpec(target, ['.spec', '.test']);
   expect(result).toBe(expected);


### PR DESCRIPTION
closes https://github.com/bisquit/vscode-fuzzy-go-to-spec/issues/4