### PR TITLE
feat: add keybinding for go to spec command

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,14 @@
         "category": "Fuzzy Go to Spec"
       }
     ],
+    "keybindings": [
+      {
+        "command": "fuzzy-go-to-spec.goToSpec",
+        "key": "ctrl+shift+t",
+        "mac": "cmd+shift+t",
+        "when": "editorTextFocus"
+      }
+    ],
     "configuration": {
       "title": "Fuzzy Go to Spec",
       "properties": {


### PR DESCRIPTION
closes https://github.com/bisquit/vscode-fuzzy-go-to-spec/issues/2